### PR TITLE
DigiExplorer API changes and failing tests for balance

### DIFF
--- a/lib/Address.js
+++ b/lib/Address.js
@@ -31,7 +31,7 @@ const deriveChildIndex = (seed, isChange, index) => {
  */
 const getNewSeed = () => {
   const seed = new Mnemonic();
-  return seed.toString();  
+  return seed.toString();
 }
 
 /**
@@ -59,12 +59,12 @@ const getSeedBalance = (seed, gap) => {
   }
   return Promise.map(pairs, pair => {
     return Explorer.getBalance(pair.mainPair.address)
-      .then(balance => {
-        pair.mainPair.balance = balance;
+      .then(txn => {
+        pair.mainPair.balance = txn.balance;
         return Explorer.getBalance(pair.changePair.address);
       })
-      .then(balance => {
-        pair.changePair.balance = balance;
+      .then(txn => {
+        pair.changePair.balance = txn.balance;
         return pair;
       });
   });

--- a/lib/Explorer.js
+++ b/lib/Explorer.js
@@ -1,6 +1,6 @@
 const request = require('request');
 
-const DIGIEXPLORER = 'https://explorer-1.us.digibyteservers.io/api/';
+const DIGIEXPLORER = 'https://digiexplorer.info/api/v1/';
 
 const getRequest = (url) => {
   return new Promise((resolve, reject) => {
@@ -24,7 +24,7 @@ const getRequest = (url) => {
  * @returns {number} the balance
  */
 const getBalance = (address) => {
-  const url = `${DIGIEXPLORER}addr/${address}/balance`;
+  const url = `${DIGIEXPLORER}address/${address}`;
   return getRequest(url);
 }
 
@@ -34,8 +34,8 @@ const getBalance = (address) => {
  * @returns {Array} Array of utxos
  */
 const getUtxos = (address) => {
-  const url = `${DIGIEXPLORER}addr/${address}/utxo`;
-  return getRequest(url);  
+  const url = `${DIGIEXPLORER}utxo/${address}`;
+  return getRequest(url);
 }
 
 module.exports = {

--- a/test/Address.test.js
+++ b/test/Address.test.js
@@ -50,7 +50,7 @@ describe('Address', () => {
   describe('getSeedBalance', () => {
     it('Should get balances for a seed', () => {
       return Address.getSeedBalance(testSeed).then(balances => {
-        expect(typeof balances).toEqual('Array');
+        expect(typeof balances).toEqual('object');
       });
     });
   });

--- a/test/Explorer.test.js
+++ b/test/Explorer.test.js
@@ -6,8 +6,8 @@ describe('Explorer', () => {
 
   describe('getBalance', () => {
     it('Should get an addresses balance', () => {
-      return Explorer.getBalance(ADDRESS).then(balance => {
-        expect(balance).toEqual(0);
+      return Explorer.getBalance(ADDRESS).then(addr => {
+        expect(addr.balance).toEqual('0');
       });
     });
   });


### PR DESCRIPTION
- Updated DIGIEXPLORER URL
- Fixed failing test cases for `getBalance`
- Added Endpoint changes as per new API in the block explorer